### PR TITLE
add a fetch function to the WorldArgs

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,10 +23,14 @@ fn main() {
         b.0 = a.0 > 0;
     });
     scheduler.run(|warg| {
-        let mut sa = warg.write::<CompInt>();
-        let sb = warg.read::<CompBool>();
+        let (mut sa, sb, entities) = warg.fetch(|comp| {
+            (comp.write::<CompInt>(),
+             comp.read::<CompBool>(),
+             comp.entities())
+        });
+
         //println!("{:?} {:?}", &*sa, &*sb);
-        for &ent in warg.entities().iter() {
+        for &ent in entities.iter() {
             use parsec::Storage;
             if let (Some(a), Some(b)) = (sa.get_mut(ent), sb.get(ent)) {
                 a.0 = if b.0 {2} else {0};


### PR DESCRIPTION
This is a bit more verbose, and I am open to alternatives.

The `WorldArgs` from before was a bit implicit in when the next system was triggered to go. It was triggered off of access to `entities`. This caused issue for me when the first thing I tried was a call that did not use this api.