### PR TITLE
Entity deletion via a deferred queue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,15 @@ impl World {
         (slock, &ci.dead_entities)
     }
     pub fn read<'a, T: Component>(&'a self) -> RwLockReadGuard<'a, T::Storage> {
-        self.lock::<T>().0.read().unwrap()
+        //self.lock::<T>().0.read().unwrap()
+        let (lock, dead_lock) = self.lock::<T>();
+        let guard = lock.read().unwrap();
+        let mut dead_guard = dead_lock.write().unwrap();
+        dead_guard.retain(|&e| guard.get(e).is_some());
+        guard
     }
     pub fn write<'a, T: Component>(&'a self) -> RwLockWriteGuard<'a, T::Storage> {
+        //self.lock::<T>().0.write().unwrap()
         let (lock, dead_lock) = self.lock::<T>();
         let mut guard = lock.write().unwrap();
         let mut dead_guard = dead_lock.write().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,14 @@ pub trait Component: Any + Sized {
     type Storage: Storage<Self> + Any + Send + Sync;
 }
 
+struct ComponentInfo {
+    any_box: Box<Any+Send+Sync>,
+    dead_entities: RwLock<Vec<Entity>>,
+}
+
 pub struct World {
     generations: RwLock<Vec<Generation>>,
-    components: HashMap<TypeId, Box<Any+Send+Sync>>,
+    components: HashMap<TypeId, ComponentInfo>,
 }
 
 impl World {
@@ -70,19 +75,28 @@ impl World {
         }
     }
     pub fn register<T: Component>(&mut self) {
-        let any = RwLock::new(T::Storage::new());
-        self.components.insert(TypeId::of::<T>(), Box::new(any));
+        self.components.insert(TypeId::of::<T>(), ComponentInfo {
+            any_box: Box::new(RwLock::new(T::Storage::new())),
+            dead_entities: RwLock::new(Vec::new()),
+        });
     }
-    fn lock<T: Component>(&self) -> &RwLock<T::Storage> {
+    fn lock<T: Component>(&self) -> (&RwLock<T::Storage>, &RwLock<Vec<Entity>>) {
         use std::ops::Deref;
-        let boxed = self.components.get(&TypeId::of::<T>()).unwrap();
-        (boxed.deref() as &Any).downcast_ref().unwrap()
+        let ci = self.components.get(&TypeId::of::<T>()).unwrap();
+        let slock = (ci.any_box.deref() as &Any).downcast_ref().unwrap();
+        (slock, &ci.dead_entities)
     }
     pub fn read<'a, T: Component>(&'a self) -> RwLockReadGuard<'a, T::Storage> {
-        self.lock::<T>().read().unwrap()
+        self.lock::<T>().0.read().unwrap()
     }
     pub fn write<'a, T: Component>(&'a self) -> RwLockWriteGuard<'a, T::Storage> {
-        self.lock::<T>().write().unwrap()
+        let (lock, dead_lock) = self.lock::<T>();
+        let mut guard = lock.write().unwrap();
+        let mut dead_guard = dead_lock.write().unwrap();
+        for e in dead_guard.drain(..) {
+            guard.sub(e);
+        }
+        guard
     }
     pub fn entities<'a>(&'a self) -> EntityIter<'a> {
         EntityIter {
@@ -172,9 +186,8 @@ impl Scheduler {
         EntityBuilder(ent, &self.world)
     }
     pub fn del_entity(&mut self, entity: Entity) {
-        for _boxed in self.world.components.values() {
-            //TODO!
-            //let lock = (boxed.deref() as &Any).downcast_ref().unwrap();
+        for ci in self.world.components.values() {
+            ci.dead_entities.write().unwrap().push(entity);
         }
         let mut gens = self.world.generations.write().unwrap();
         let mut gen = &mut gens[entity.get_id() as usize];

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -36,7 +36,11 @@ impl<T> Storage<T> for VecStorage<T> {
         self.0[entity.get_id()] = Some((entity.get_gen(), value));
     }
     fn sub(&mut self, entity: Entity) -> Option<T>{
-        self.0[entity.get_id()].take().map(|(_, v)| v)
+        match self.0[entity.get_id()] {
+            Some((g, _)) if g == entity.get_gen() =>
+                Some(self.0[entity.get_id()].take().unwrap().1),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #3 

Needs to be discussed and evaluated before merging, since there are use-cases that would make it leak data. For example, if any component is not locked for writing for a long time, it's deletion queue will grow unbound even though the affected entities may not even have this component.

On the other hand, this change is not visible in the API and can be reversed at any point later on.