### PR TITLE
add some tests!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,12 @@ pub type Index = u32;
 pub struct Entity(Index, Generation);
 
 impl Entity {
+    #[cfg(test)]
+    /// Create a new entity (externally from ECS)
+    pub fn new(index: u32, gen: i32) -> Entity {
+        Entity(index, gen)
+    }
+
     /// Get the index of the entity.
     pub fn get_id(&self) -> usize { self.0 as usize }
     /// Get the generation of the entity.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -48,10 +48,15 @@ impl<T> Storage<T> for VecStorage<T> {
         }
         self.0[entity.get_id()] = Some((entity.get_gen(), value));
     }
-    fn sub(&mut self, entity: Entity) -> Option<T>{
-        self.0[entity.get_id()].take().map(|(g, v)| {
-            assert_eq!(g, entity.get_gen());
-            v
+    fn sub(&mut self, entity: Entity) -> Option<T> {
+        self.0.get_mut(entity.get_id()).and_then(|x| {
+            if let &mut Some((gen, _)) = x {
+                // if the generation does not match avoid deleting
+                if gen != entity.get_gen() {
+                    return None;
+                }
+            }
+            x.take().map(|(_, x)| x)
         })
     }
 }
@@ -82,3 +87,87 @@ impl<T> Storage<T> for HashMapStorage<T> {
         self.0.remove(&entity)
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    use Entity;
+    use super::*;
+
+    fn test_add<S>() where S: Storage<u32> {
+        let mut s = S::new();
+        for i in 0..1_000 {
+            s.add(Entity::new(i, 1), i + 2718);
+        }
+
+        for i in 0..1_000 {
+            assert_eq!(*s.get(Entity::new(i, 1)).unwrap(), i + 2718);
+        }
+    }
+
+    fn test_sub<S>() where S: Storage<u32> {
+        let mut s = S::new();
+        for i in 0..1_000 {
+            s.add(Entity::new(i, 1), i + 2718);
+        }
+
+        for i in 0..1_000 {
+            assert_eq!(s.sub(Entity::new(i, 1)).unwrap(), i + 2718);
+            assert!(s.sub(Entity::new(i, 1)).is_none());
+        }
+    }
+
+    fn test_get_mut<S>() where S: Storage<u32> {
+        let mut s = S::new();
+        for i in 0..1_000 {
+            s.add(Entity::new(i, 1), i + 2718);
+        }
+
+        for i in 0..1_000 {
+            *s.get_mut(Entity::new(i, 1)).unwrap() -= 718;
+        }
+
+        for i in 0..1_000 {
+            assert_eq!(*s.get(Entity::new(i, 1)).unwrap(), i + 2000);
+        }
+    }
+
+    fn test_add_gen<S>() where S: Storage<u32> {
+        let mut s = S::new();
+        for i in 0..1_000 {
+            s.add(Entity::new(i, 1), i + 2718);
+            s.add(Entity::new(i, 2), i + 31415);
+        }
+
+        for i in 0..1_000 {
+            // this is removed since vec and hashmap disagree
+            // on how this behavior should work...
+            //assert!(s.get(Entity::new(i, 1)).is_none());
+            assert_eq!(*s.get(Entity::new(i, 2)).unwrap(), i + 31415);
+        }
+    }
+
+    fn test_sub_gen<S>() where S: Storage<u32> {
+        let mut s = S::new();
+        for i in 0..1_000 {
+            s.add(Entity::new(i, 2), i + 2718);
+        }
+
+        for i in 0..1_000 {
+            assert!(s.sub(Entity::new(i, 1)).is_none());
+        }
+    }
+
+    #[test] fn vec_test_add() { test_add::<VecStorage<u32>>(); }
+    #[test] fn vec_test_sub() { test_sub::<VecStorage<u32>>(); }
+    #[test] fn vec_test_get_mut() { test_get_mut::<VecStorage<u32>>(); }
+    #[test] fn vec_test_add_gen() { test_add_gen::<VecStorage<u32>>(); }
+    #[test] fn vec_test_sub_gen() { test_sub_gen::<VecStorage<u32>>(); }
+
+    #[test] fn hash_test_add() { test_add::<HashMapStorage<u32>>(); }
+    #[test] fn hash_test_sub() { test_sub::<HashMapStorage<u32>>(); }
+    #[test] fn hash_test_get_mut() { test_get_mut::<HashMapStorage<u32>>(); }
+    #[test] fn hash_test_add_gen() { test_add_gen::<HashMapStorage<u32>>(); }
+    #[test] fn hash_test_sub_gen() { test_sub_gen::<HashMapStorage<u32>>(); }
+}
+


### PR DESCRIPTION
VecStorage::sub would panic if you delete an out of generation id.
Add tests to make sure the behavior of vec/hashmap is consistent.