### PR TITLE
Renamed add/sub to insert/remove

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub struct EntityBuilder<'a>(Entity, &'a World);
 impl<'a> EntityBuilder<'a> {
     /// Add a component value to the new entity.
     pub fn with<T: Component>(self, value: T) -> EntityBuilder<'a> {
-        self.1.write::<T>().add(self.0, value);
+        self.1.write::<T>().insert(self.0, value);
         self
     }
     /// Finish entity construction.


### PR DESCRIPTION
@csherratt you were asking for it, yet used the old add/sub extensively in the tests. I wonder if there is a reason to stay with the old names.